### PR TITLE
Implement null-if-empty check

### DIFF
--- a/src/InputValueGetter.php
+++ b/src/InputValueGetter.php
@@ -17,7 +17,7 @@ trait InputValueGetter {
 
 	public function getInt(string $key):?int {
 		$value = $this->getString($key);
-		if(is_null($value)) {
+		if(is_null($value) || strlen($value) === 0) {
 			return null;
 		}
 
@@ -26,7 +26,7 @@ trait InputValueGetter {
 
 	public function getFloat(string $key):?float {
 		$value = $this->getString($key);
-		if(is_null($value)) {
+		if(is_null($value) || strlen($value) === 0) {
 			return null;
 		}
 
@@ -35,7 +35,7 @@ trait InputValueGetter {
 
 	public function getBool(string $key):?bool {
 		$value = $this->getString($key);
-		if(is_null($value)) {
+		if(is_null($value) || strlen($value) === 0) {
 			return null;
 		}
 
@@ -68,14 +68,32 @@ trait InputValueGetter {
 		return $this->get($key);
 	}
 
-	public function getDateTime(string $key):DateTimeInterface {
+	public function getDateTime(
+		string $key,
+		string $format = null
+	):?DateTimeInterface {
+		$value = $this->getString($key);
+		if(is_null($value) || strlen($value) === 0) {
+			return null;
+		}
+
 		try {
-			$dateTime = new DateTime($this[$key]);
-			return $dateTime;
+			if($format) {
+				$dateTime = DateTime::createFromFormat($format, $value);
+			}
+			else {
+				$dateTime = new DateTime($value);
+			}
 		}
 		catch(Exception $exception) {
+			$dateTime = false;
+		}
+
+		if($dateTime === false) {
 			throw new DataNotCompatibleFormatException($key);
 		}
+
+		return $dateTime;
 	}
 
 	/**

--- a/test/unit/InputTest.php
+++ b/test/unit/InputTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Gt\Input\Test;
 
+use DateTime;
+use Gt\Input\DataNotCompatibleFormatException;
 use Gt\Input\Input;
 use Gt\Input\InputData\Datum\FileUpload;
 use Gt\Input\InputData\InputData;
@@ -17,6 +19,10 @@ class InputTest extends TestCase {
 		"half-of-five" => "2.5",
 		"many-dots" => "1.2.3.4",
 		"this-is-positive" => "oh yes",
+		"a-date-without-timezone" => "2005-08-15T15:52:00",
+		"a-date-with-timezone" => "2005-08-15T16:52:00+01:00",
+		"a-date-without-timezone-or-seconds" => "2005-08-15T15:52",
+		"a-date-in-rss-format" => "Mon, 15 Aug 2005 15:52:00 +0000",
 		"empty-value" => "",
 	];
 	const FAKE_FILE = [
@@ -495,6 +501,29 @@ class InputTest extends TestCase {
 		self::assertSame(true, $input->getBool("this-is-positive"));
 		self::assertNull($input->getBool("empty-value"));
 		self::assertNull($input->getBool("not-set"));
+	}
+
+	public function testGetDateTime():void {
+		$dateTime = new DateTime("2005-08-15T15:52");
+
+		$input = new Input(self::FAKE_DATA);
+		self::assertNull($input->getDateTime("empty-value"));
+		self::assertEquals($dateTime, $input->getDateTime("a-date-with-timezone"));
+		self::assertEquals($dateTime, $input->getDateTime("a-date-without-timezone"));
+		self::assertEquals($dateTime, $input->getDateTime("a-date-without-timezone-or-seconds"));
+	}
+
+	public function testGetDateTimeInvalid():void {
+		$input = new Input(self::FAKE_DATA);
+		self::expectException(DataNotCompatibleFormatException::class);
+		$input->getDateTime("one-plus-one");
+	}
+
+	public function testGetDateTimeFromFormat():void {
+		$dateTime = new DateTime("2005-08-15T15:52");
+
+		$input = new Input(self::FAKE_DATA);
+		self::assertEquals($dateTime, $input->getDateTime("a-date-in-rss-format"));
 	}
 
 	/** @dataProvider dataRandomGetPost */

--- a/test/unit/InputTest.php
+++ b/test/unit/InputTest.php
@@ -471,7 +471,7 @@ class InputTest extends TestCase {
 		self::assertSame(2, $input->getInt("one-plus-one"));
 		self::assertSame(1, $input->getInt("many-dots"));
 		self::assertSame(0, $input->getInt("this-is-positive"));
-		self::assertSame(0, $input->getInt("empty-value"));
+		self::assertNull($input->getInt("empty-value"));
 		self::assertNull($input->getInt("not-set"));
 	}
 
@@ -482,7 +482,7 @@ class InputTest extends TestCase {
 		self::assertSame(2.5, $input->getFloat("half-of-five"));
 		self::assertSame(1.2, $input->getFloat("many-dots"));
 		self::assertSame(0.0, $input->getFloat("this-is-positive"));
-		self::assertSame(0.0, $input->getFloat("empty-value"));
+		self::assertNull($input->getFloat("empty-value"));
 		self::assertNull($input->getFloat("not-set"));
 	}
 
@@ -493,7 +493,7 @@ class InputTest extends TestCase {
 		self::assertSame(true, $input->getBool("half-of-five"));
 		self::assertSame(true, $input->getBool("many-dots"));
 		self::assertSame(true, $input->getBool("this-is-positive"));
-		self::assertSame(false, $input->getBool("empty-value"));
+		self::assertNull($input->getBool("empty-value"));
 		self::assertNull($input->getBool("not-set"));
 	}
 


### PR DESCRIPTION
For all typed InputGetter functions apart from getString, if the input is an empty string, the result should be null.